### PR TITLE
fix: PhpCall (PhpVar) translating to 'name' instead of '$name'

### DIFF
--- a/src/peeble/PhpOutput.fs
+++ b/src/peeble/PhpOutput.fs
@@ -191,6 +191,8 @@ let rec writeExpr ctx expr =
         match f with
         | PhpConst (PhpConstString f) ->
             write ctx f
+        | PhpVar (name, _) ->
+            write ctx name
         | _ -> writeExpr ctx f
         if anonymous then
             write ctx ")"


### PR DESCRIPTION
I was getting outputs where the code was calling 

```php
$fn($arg1, $arg2)
```

instead of


```php
fn($arg1, $arg2)
```

(which caused a problem because the variable `$fn` doesn't exist)

Probably because this line is commented out https://github.com/thinkbeforecoding/peeble/blob/244c6f5ed87b9d96755b2fd44ea710c0dbcbd3db/src/peeble/Transforms.fs#L404