### PR TITLE
feat: add convertFromJson

### DIFF
--- a/src/FSharp.Core/FSharp.Core.php
+++ b/src/FSharp.Core/FSharp.Core.php
@@ -85,10 +85,10 @@ class Util {
     }
 }
 interface Union {
-    public function get_Case();
+    public static function get_Case();
 }
 interface FSharpUnion {
-    public function get_FSharpCase();
+    public static function get_FSharpCase();
 }
 
 


### PR DESCRIPTION
This PR adds some reflection methods and a convertFromSimpleJson function to the serialization class.

I had to add `get_X_Type` methods in order to make it work instead of setting the type of the variables because 
1. The current type would include aliases which are unknown in PHP and I wasn't sure how to declare them
2. PHP doesn't support generics AFAIK and e.g. to decode a List<T>, you need to know what T is and that would otherwise be stripped. I could have added those methods only in the case they are a list but that would have probably made it a bit complex.